### PR TITLE
Update pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<repositories>
+    <repository>
+        <id>alimaven</id>
+        <url>https://maven.aliyun.com/repository/public</url>
+    </repository>
+</repositories>
+ 
+<pluginRepositories>
+    <pluginRepository>
+        <id>alimaven</id>
+        <url>https://maven.aliyun.com/repository/public</url>
+    </pluginRepository>
+</pluginRepositories>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
@@ -150,6 +163,7 @@
     </dependencies>
 
     <build>
+        <defaultGoal>compile</defaultGoal>     
         <plugins>
             <plugin>
                 <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
由于原版下载组件是到maven.apache.org下载，很慢，更新aliyun地址。同时添加指定的goal，需要在项目的pom.xml文件中，添加一项goal数据。